### PR TITLE
Fix Docker Compose config for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 После запуска:
 
 ```bash
-curl -X POST http://localhost:5050/auth/register \
+curl -X POST http://localhost:5000/auth/register \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "1234"}'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,9 @@ services:
     build: ./frontend
     restart: always
     environment:
-      - VITE_API_URL=http://localhost:5000
+      - VITE_API_URL=http://backend:5000
     ports:
-      - 3000:80
+      - 5173:5173
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- correct frontend port mapping and backend url in `docker-compose.yml`
- update README to point to correct API port

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887d5c1383083249a2cc2883d5395cc