### PR TITLE
Fix compose frontend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,13 @@ services:
     depends_on:
       - mongo
 
-  rontend:
+  frontend:
     build: ./frontend
     ports:
       - "5173:5173"  
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
     environment:
-      - VITE_API_URL=http://backend:5000 
+      - VITE_API_URL=http://localhost:5001
 
 volumes:
   mongo-data:


### PR DESCRIPTION
## Summary
- rename `rontend` service to `frontend`
- update environment variable to use localhost URL

## Testing
- `docker compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f431fe048324bbc0d68c8771bcb0